### PR TITLE
[feat] Faster Yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,41 +18,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
-
-[[package]]
-name = "itoa"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
-dependencies = [
- "unicode-ident",
-]
 
 [[package]]
 name = "pulldown-cmark"
@@ -73,83 +36,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
 name = "qwik-city-content"
 version = "0.1.0"
 dependencies = [
  "pulldown-cmark",
- "serde",
- "serde_json",
- "serde_yaml",
-]
-
-[[package]]
-name = "ryu"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
-
-[[package]]
-name = "serde"
-version = "1.0.144"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.144"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a09f551ccc8210268ef848f0bab37b306e87b85b2e017b899e7fb815f5aed62"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -162,22 +52,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,4 @@ codegen-units = 1
 panic = "abort"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
-serde_json = "1.0"
 pulldown-cmark = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"

--- a/examples/blog/package-lock.json
+++ b/examples/blog/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "name": "blog",
       "devDependencies": {
-        "@builder.io/qwik": "0.0.105",
-        "@builder.io/qwik-city": "0.0.104",
+        "@builder.io/qwik": "^0.0.107",
+        "@builder.io/qwik-city": "^0.0.107",
         "@types/eslint": "8.4.6",
         "@types/node": "latest",
         "@typescript-eslint/eslint-plugin": "5.34.0",
@@ -25,21 +25,21 @@
       }
     },
     "node_modules/@builder.io/qwik": {
-      "version": "0.0.105",
-      "resolved": "https://registry.npmjs.org/@builder.io/qwik/-/qwik-0.0.105.tgz",
-      "integrity": "sha512-FiCpyqldEVxjFHikjLMWgkX7ivoiS/VVB4oFI3CzlgjRJ5ob7ChFu5qEYrTNpniLp+1AjfNIWLm6E9ndR5tWEQ==",
+      "version": "0.0.107",
+      "resolved": "https://registry.npmjs.org/@builder.io/qwik/-/qwik-0.0.107.tgz",
+      "integrity": "sha512-wYuICxvI8Ar9JGyvK4/05whD/FsdkJqzpVMq5ClzHE4L+XaurmMkr6KcpMVeMnYXGDx1hLI4FFQIWNSiUrUNxw==",
       "dev": true,
       "engines": {
         "node": ">=14.18.0"
       }
     },
     "node_modules/@builder.io/qwik-city": {
-      "version": "0.0.104",
-      "resolved": "https://registry.npmjs.org/@builder.io/qwik-city/-/qwik-city-0.0.104.tgz",
-      "integrity": "sha512-XBd1HtDYakHuiJS6jxRx76+Sofy6tvDWRQsF0ROQ0QNuxz88VeMPTp+JYjYw5PedxHnZmGgl/X2GEhRZ/Sb5YA==",
+      "version": "0.0.107",
+      "resolved": "https://registry.npmjs.org/@builder.io/qwik-city/-/qwik-city-0.0.107.tgz",
+      "integrity": "sha512-tM0491VIDKQeN72yAdeAzLVa8gJkS6sazMFrsK/fwnfg8tJCQmoLb8JM8WoLIHD3b5ESFPBu/QTPD+Xv7oYTMA==",
       "dev": true,
       "dependencies": {
-        "@mdx-js/mdx": "2.1.2",
+        "@mdx-js/mdx": "2.1.3",
         "@types/mdx": "2.0.2",
         "source-map": "0.7.4",
         "vfile": "5.3.4"
@@ -118,16 +118,16 @@
       "dev": true
     },
     "node_modules/@mdx-js/mdx": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.1.2.tgz",
-      "integrity": "sha512-ASN1GUH0gXsgJ2UD/Td7FzJo1SwFkkQ5V1i9at5o/ROra7brkyMcBsotsOWJWRzmXZaLw2uXWn4aN8B3PMNFMA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.1.3.tgz",
+      "integrity": "sha512-ahbb47HJIJ4xnifaL06tDJiSyLEy1EhFAStO7RZIm3GTa7yGW3NGhZaj+GUCveFgl5oI54pY4BgiLmYm97y+zg==",
       "dev": true,
       "dependencies": {
-        "@types/estree-jsx": "^0.0.1",
+        "@types/estree-jsx": "^1.0.0",
         "@types/mdx": "^2.0.0",
-        "astring": "^1.6.0",
         "estree-util-build-jsx": "^2.0.0",
         "estree-util-is-identifier-name": "^2.0.0",
+        "estree-util-to-js": "^1.1.0",
         "estree-walker": "^3.0.0",
         "hast-util-to-estree": "^2.0.0",
         "markdown-extensions": "^1.0.0",
@@ -216,9 +216,9 @@
       "dev": true
     },
     "node_modules/@types/estree-jsx": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-0.0.1.tgz",
-      "integrity": "sha512-gcLAYiMfQklDCPjQegGn0TBAn9it05ISEsEhlKQUddIk7o2XDokOcTN7HBO8tznM0D9dGezvHEfRZBfZf6me0A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
+      "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*"
@@ -1398,20 +1398,26 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/estree-util-build-jsx/node_modules/@types/estree-jsx": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
-      "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*"
-      }
-    },
     "node_modules/estree-util-is-identifier-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-2.0.1.tgz",
       "integrity": "sha512-rxZj1GkQhY4x1j/CSnybK9cGuMFQYFPLq0iNyopqf14aOVLFtMv7Esika+ObJWPWiOHuMOAHz3YkWoLYYRnzWQ==",
       "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-1.1.0.tgz",
+      "integrity": "sha512-490lbfCcpLk+ofK6HCgqDfYs4KAfq6QVvDw3+Bm1YoKRgiOjKiKYGAVQE1uwh7zVxBgWhqp4FDtp5SqunpUk1A==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -1429,15 +1435,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/estree-util-visit/node_modules/@types/estree-jsx": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
-      "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*"
       }
     },
     "node_modules/estree-walker": {
@@ -1773,15 +1770,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-estree/node_modules/@types/estree-jsx": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
-      "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*"
       }
     },
     "node_modules/hast-util-whitespace": {
@@ -2167,15 +2155,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdast-util-mdx-expression/node_modules/@types/estree-jsx": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
-      "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*"
-      }
-    },
     "node_modules/mdast-util-mdx-jsx": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-2.1.0.tgz",
@@ -2198,15 +2177,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdast-util-mdx-jsx/node_modules/@types/estree-jsx": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
-      "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*"
-      }
-    },
     "node_modules/mdast-util-mdxjs-esm": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-1.3.0.tgz",
@@ -2222,15 +2192,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-mdxjs-esm/node_modules/@types/estree-jsx": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
-      "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*"
       }
     },
     "node_modules/mdast-util-to-hast": {
@@ -4009,18 +3970,18 @@
   },
   "dependencies": {
     "@builder.io/qwik": {
-      "version": "0.0.105",
-      "resolved": "https://registry.npmjs.org/@builder.io/qwik/-/qwik-0.0.105.tgz",
-      "integrity": "sha512-FiCpyqldEVxjFHikjLMWgkX7ivoiS/VVB4oFI3CzlgjRJ5ob7ChFu5qEYrTNpniLp+1AjfNIWLm6E9ndR5tWEQ==",
+      "version": "0.0.107",
+      "resolved": "https://registry.npmjs.org/@builder.io/qwik/-/qwik-0.0.107.tgz",
+      "integrity": "sha512-wYuICxvI8Ar9JGyvK4/05whD/FsdkJqzpVMq5ClzHE4L+XaurmMkr6KcpMVeMnYXGDx1hLI4FFQIWNSiUrUNxw==",
       "dev": true
     },
     "@builder.io/qwik-city": {
-      "version": "0.0.104",
-      "resolved": "https://registry.npmjs.org/@builder.io/qwik-city/-/qwik-city-0.0.104.tgz",
-      "integrity": "sha512-XBd1HtDYakHuiJS6jxRx76+Sofy6tvDWRQsF0ROQ0QNuxz88VeMPTp+JYjYw5PedxHnZmGgl/X2GEhRZ/Sb5YA==",
+      "version": "0.0.107",
+      "resolved": "https://registry.npmjs.org/@builder.io/qwik-city/-/qwik-city-0.0.107.tgz",
+      "integrity": "sha512-tM0491VIDKQeN72yAdeAzLVa8gJkS6sazMFrsK/fwnfg8tJCQmoLb8JM8WoLIHD3b5ESFPBu/QTPD+Xv7oYTMA==",
       "dev": true,
       "requires": {
-        "@mdx-js/mdx": "2.1.2",
+        "@mdx-js/mdx": "2.1.3",
         "@types/mdx": "2.0.2",
         "source-map": "0.7.4",
         "vfile": "5.3.4"
@@ -4080,16 +4041,16 @@
       "dev": true
     },
     "@mdx-js/mdx": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.1.2.tgz",
-      "integrity": "sha512-ASN1GUH0gXsgJ2UD/Td7FzJo1SwFkkQ5V1i9at5o/ROra7brkyMcBsotsOWJWRzmXZaLw2uXWn4aN8B3PMNFMA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.1.3.tgz",
+      "integrity": "sha512-ahbb47HJIJ4xnifaL06tDJiSyLEy1EhFAStO7RZIm3GTa7yGW3NGhZaj+GUCveFgl5oI54pY4BgiLmYm97y+zg==",
       "dev": true,
       "requires": {
-        "@types/estree-jsx": "^0.0.1",
+        "@types/estree-jsx": "^1.0.0",
         "@types/mdx": "^2.0.0",
-        "astring": "^1.6.0",
         "estree-util-build-jsx": "^2.0.0",
         "estree-util-is-identifier-name": "^2.0.0",
+        "estree-util-to-js": "^1.1.0",
         "estree-walker": "^3.0.0",
         "hast-util-to-estree": "^2.0.0",
         "markdown-extensions": "^1.0.0",
@@ -4165,9 +4126,9 @@
       "dev": true
     },
     "@types/estree-jsx": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-0.0.1.tgz",
-      "integrity": "sha512-gcLAYiMfQklDCPjQegGn0TBAn9it05ISEsEhlKQUddIk7o2XDokOcTN7HBO8tznM0D9dGezvHEfRZBfZf6me0A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
+      "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
       "dev": true,
       "requires": {
         "@types/estree": "*"
@@ -4904,17 +4865,6 @@
         "@types/estree-jsx": "^1.0.0",
         "estree-util-is-identifier-name": "^2.0.0",
         "estree-walker": "^3.0.0"
-      },
-      "dependencies": {
-        "@types/estree-jsx": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
-          "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
-          "dev": true,
-          "requires": {
-            "@types/estree": "*"
-          }
-        }
       }
     },
     "estree-util-is-identifier-name": {
@@ -4922,6 +4872,17 @@
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-2.0.1.tgz",
       "integrity": "sha512-rxZj1GkQhY4x1j/CSnybK9cGuMFQYFPLq0iNyopqf14aOVLFtMv7Esika+ObJWPWiOHuMOAHz3YkWoLYYRnzWQ==",
       "dev": true
+    },
+    "estree-util-to-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-1.1.0.tgz",
+      "integrity": "sha512-490lbfCcpLk+ofK6HCgqDfYs4KAfq6QVvDw3+Bm1YoKRgiOjKiKYGAVQE1uwh7zVxBgWhqp4FDtp5SqunpUk1A==",
+      "dev": true,
+      "requires": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      }
     },
     "estree-util-visit": {
       "version": "1.2.0",
@@ -4931,17 +4892,6 @@
       "requires": {
         "@types/estree-jsx": "^1.0.0",
         "@types/unist": "^2.0.0"
-      },
-      "dependencies": {
-        "@types/estree-jsx": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
-          "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
-          "dev": true,
-          "requires": {
-            "@types/estree": "*"
-          }
-        }
       }
     },
     "estree-walker": {
@@ -5201,17 +5151,6 @@
         "style-to-object": "^0.3.0",
         "unist-util-position": "^4.0.0",
         "zwitch": "^2.0.0"
-      },
-      "dependencies": {
-        "@types/estree-jsx": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
-          "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
-          "dev": true,
-          "requires": {
-            "@types/estree": "*"
-          }
-        }
       }
     },
     "hast-util-whitespace": {
@@ -5481,17 +5420,6 @@
         "@types/mdast": "^3.0.0",
         "mdast-util-from-markdown": "^1.0.0",
         "mdast-util-to-markdown": "^1.0.0"
-      },
-      "dependencies": {
-        "@types/estree-jsx": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
-          "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
-          "dev": true,
-          "requires": {
-            "@types/estree": "*"
-          }
-        }
       }
     },
     "mdast-util-mdx-jsx": {
@@ -5510,17 +5438,6 @@
         "unist-util-remove-position": "^4.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "vfile-message": "^3.0.0"
-      },
-      "dependencies": {
-        "@types/estree-jsx": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
-          "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
-          "dev": true,
-          "requires": {
-            "@types/estree": "*"
-          }
-        }
       }
     },
     "mdast-util-mdxjs-esm": {
@@ -5534,17 +5451,6 @@
         "@types/mdast": "^3.0.0",
         "mdast-util-from-markdown": "^1.0.0",
         "mdast-util-to-markdown": "^1.0.0"
-      },
-      "dependencies": {
-        "@types/estree-jsx": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
-          "integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
-          "dev": true,
-          "requires": {
-            "@types/estree": "*"
-          }
-        }
       }
     },
     "mdast-util-to-hast": {

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -16,8 +16,8 @@
     "typecheck": "tsc --incremental --noEmit"
   },
   "devDependencies": {
-    "@builder.io/qwik": "0.0.105",
-    "@builder.io/qwik-city": "0.0.104",
+    "@builder.io/qwik": "^0.0.107",
+    "@builder.io/qwik-city": "^0.0.107",
     "@types/eslint": "8.4.6",
     "@types/node": "latest",
     "@typescript-eslint/eslint-plugin": "5.34.0",

--- a/examples/blog/src/content/posts/post-6.md
+++ b/examples/blog/src/content/posts/post-6.md
@@ -1,0 +1,12 @@
+---
+title: "Post-6"
+date: "2022-08-21"
+description: "Sixth Post"
+tags: ["blog", "qwik", "qwik city", "@#!="]
+---
+
+Aute dolore exercitation consequat ipsum. Occaecat qui ad excepteur ad quis. Excepteur consequat culpa aliquip esse eu veniam anim eu magna.
+
+Qui ad proident cillum voluptate fugiat commodo duis aliquip magna sit labore. Ullamco exercitation in fugiat tempor occaecat esse aliqua. Proident proident non magna sint qui minim incididunt do voluptate ut adipisicing proident. Anim laboris veniam veniam est nisi qui magna nostrud incididunt velit do minim commodo. Tempor dolore laborum mollit do in ut velit ex do cillum laborum amet laboris.
+
+Consequat fugiat nostrud id dolor Lorem ut officia irure sit aliquip. Sit Lorem deserunt sint deserunt non laboris sunt. Nisi voluptate dolore id adipisicing deserunt commodo excepteur.

--- a/examples/blog/src/content/posts/subfolder/post-5.md
+++ b/examples/blog/src/content/posts/subfolder/post-5.md
@@ -1,0 +1,12 @@
+---
+title: "Post-5"
+date: "2022-08-24"
+description: "Fifth Post"
+tags: ["blog", "qwik", "qwik city", "@#!="]
+---
+
+Aute dolore exercitation consequat ipsum. Occaecat qui ad excepteur ad quis. Excepteur consequat culpa aliquip esse eu veniam anim eu magna.
+
+Qui ad proident cillum voluptate fugiat commodo duis aliquip magna sit labore. Ullamco exercitation in fugiat tempor occaecat esse aliqua. Proident proident non magna sint qui minim incididunt do voluptate ut adipisicing proident. Anim laboris veniam veniam est nisi qui magna nostrud incididunt velit do minim commodo. Tempor dolore laborum mollit do in ut velit ex do cillum laborum amet laboris.
+
+Consequat fugiat nostrud id dolor Lorem ut officia irure sit aliquip. Sit Lorem deserunt sint deserunt non laboris sunt. Nisi voluptate dolore id adipisicing deserunt commodo excepteur.

--- a/examples/blog/src/content/testimonials/glenn-becker.md
+++ b/examples/blog/src/content/testimonials/glenn-becker.md
@@ -1,0 +1,10 @@
+---
+name: "Glenn Becker"
+profile: "http://somecdn/glenn-becker.jpg"
+---
+
+Aute dolore exercitation consequat ipsum. Occaecat qui ad excepteur ad quis. Excepteur consequat culpa aliquip esse eu veniam anim eu magna.
+
+Qui ad proident cillum voluptate fugiat commodo duis aliquip magna sit labore. Ullamco exercitation in fugiat tempor occaecat esse aliqua. Proident proident non magna sint qui minim incididunt do voluptate ut adipisicing proident. Anim laboris veniam veniam est nisi qui magna nostrud incididunt velit do minim commodo. Tempor dolore laborum mollit do in ut velit ex do cillum laborum amet laboris.
+
+Consequat fugiat nostrud id dolor Lorem ut officia irure sit aliquip. Sit Lorem deserunt sint deserunt non laboris sunt. Nisi voluptate dolore id adipisicing deserunt commodo excepteur.

--- a/examples/blog/src/routes/index.tsx
+++ b/examples/blog/src/routes/index.tsx
@@ -8,12 +8,10 @@ export default component$(() => {
 
       <p>The blog meta-framework for Qwik.</p>
 
-      <h3>
-        <p>Recent Posts</p>
-        <ul>
+      <h3 id="recent-posts">Recent Posts</h3>
+      <ul aria-labelledby="recent-posts">
 
-        </ul>
-      </h3>
+      </ul>
     </div>
   );
 });

--- a/examples/blog/src/routes/post/[id]/index.tsx
+++ b/examples/blog/src/routes/post/[id]/index.tsx
@@ -1,5 +1,33 @@
-import { component$ } from "@builder.io/qwik";
+import { component$, Resource } from "@builder.io/qwik";
+import { RequestHandler, useEndpoint } from "@builder.io/qwik-city";
+import * as Taxonomies from "@content/taxonomies";
+import { RouteParams } from "./generated";
 
 export default component$(() => {
-  return <></>
+  const data = useEndpoint<typeof onGet>();
+  return <Resource value={data} onResolved={(page) => {
+    return <article>
+      <header>
+        <h1>{page.title}</h1>
+        {!!page.description && <p>{page.description}</p>}
+      </header>
+      <div class="content" dangerouslySetInnerHTML={page._html} />
+
+      <h2 id="tags">Tags</h2>
+      <ul aria-labelledby="tags">
+        {page.tags.map(tag => <a href={`/tags/${tag}`}>{tag}</a>)}
+      </ul>
+    </article>
+  }}
+  />
 })
+
+export const onGet: RequestHandler<Taxonomies.Posts> = ({ params, response }) => {
+  let { id } = params as RouteParams;
+  let post = Taxonomies.posts.find(p => p._id == +id);
+  if (!post) {
+    console.log("No post found")
+    throw response.error(404)
+  }
+  return post
+}

--- a/src/jobs/generate_route_params.rs
+++ b/src/jobs/generate_route_params.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::route_params::RouteParams;
 
+#[inline]
 pub fn generate<P: AsRef<Path>>(routes: P) -> std::io::Result<usize> {
     let mut count = 0;
     generate_route_params_rec(routes, &mut count)?;

--- a/src/jobs/process_markdown.rs
+++ b/src/jobs/process_markdown.rs
@@ -25,22 +25,23 @@ pub fn generate(
     {
         let outdir: &Path = &config.output;
         let output = outdir.join(format!("{}.tsx", &stripped));
-        let data = match Page::create(
-            &stripped,
-            &output,
+        let _yaml = crate::yaml::Parser::from_str(
             &content[ranges.frontmatter.start..ranges.frontmatter.end],
-            &content[ranges.body.start..ranges.body.end],
-        ) {
-            Some(data) => data,
-            _ => return Ok(()),
-        };
+        )
+        .parse();
         if let Some(parent) = output.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
         let file = File::create(&output)?;
         let mut writer = BufWriter::new(file);
         let _ = writer.write(b"export default ")?;
-        let _ = writer.write(serde_json::to_string(&data).unwrap().as_bytes())?;
+        Page::write(
+            &stripped,
+            &output,
+            &content[ranges.frontmatter.start..ranges.frontmatter.end],
+            &content[ranges.body.start..ranges.body.end],
+            &mut writer,
+        )?;
         writer.flush()?;
     }
     Ok(())

--- a/src/jobs/process_markdown.rs
+++ b/src/jobs/process_markdown.rs
@@ -10,6 +10,7 @@ use crate::{
     utils::ContentRanges,
 };
 
+#[inline]
 pub fn generate(
     ranges: ContentRanges,
     content: String,
@@ -39,8 +40,7 @@ pub fn generate(
         let file = File::create(&output)?;
         let mut writer = BufWriter::new(file);
         let _ = writer.write(b"export default ")?;
-        let exports = serde_json::to_string_pretty(&data)?;
-        let _ = writer.write(exports.replace("\"Content\"", "Content").as_bytes());
+        let _ = writer.write(serde_json::to_string(&data).unwrap().as_bytes())?;
         writer.flush()?;
     }
     Ok(())

--- a/src/jobs/write_collections.rs
+++ b/src/jobs/write_collections.rs
@@ -10,6 +10,9 @@ use crate::{
 
 #[inline]
 pub fn generate(config: Arc<Config>, gen: Arc<GeneratedData>) -> std::io::Result<()> {
+    if gen.output_paths.is_empty() {
+        return Ok(());
+    }
     std::fs::create_dir_all(&config.output)?;
     let file = std::fs::File::create(config.output.join("collections.ts"))?;
     let mut writer = BufWriter::new(file);
@@ -29,7 +32,7 @@ pub fn generate(config: Arc<Config>, gen: Arc<GeneratedData>) -> std::io::Result
         let mut id_iter = ids.iter();
         let _ = writer.write("export const ".as_bytes())?;
         write_snake_case(tag, &mut writer)?;
-        let _ = writer.write(": Tagged".as_bytes())?;
+        let _ = writer.write(": ".as_bytes())?;
         write_camel_case(tag, &mut writer)?;
         let _ = writer.write("[] = [".as_bytes())?;
         if let Some(first) = id_iter.next() {
@@ -45,7 +48,7 @@ pub fn generate(config: Arc<Config>, gen: Arc<GeneratedData>) -> std::io::Result
 
     for (tag, ids) in gen.collections.iter() {
         let mut id_iter = ids.iter();
-        let _ = writer.write("export type Tagged".as_bytes())?;
+        let _ = writer.write("export type ".as_bytes())?;
         write_camel_case(tag, &mut writer)?;
         let _ = writer.write(" = Merge<".as_bytes())?;
         if let Some(first) = id_iter.next() {

--- a/src/jobs/write_collections.rs
+++ b/src/jobs/write_collections.rs
@@ -5,9 +5,10 @@ use std::{
 
 use crate::{
     types::{Config, GeneratedData},
-    utils::{camel_case, snake_case},
+    utils::{write_camel_case, write_snake_case},
 };
 
+#[inline]
 pub fn generate(config: Arc<Config>, gen: Arc<GeneratedData>) -> std::io::Result<()> {
     std::fs::create_dir_all(&config.output)?;
     let file = std::fs::File::create(config.output.join("collections.ts"))?;
@@ -26,11 +27,11 @@ pub fn generate(config: Arc<Config>, gen: Arc<GeneratedData>) -> std::io::Result
 
     for (tag, ids) in gen.collections.iter() {
         let mut id_iter = ids.iter();
-        writer.write_fmt(format_args!(
-            "export const {}: Tagged{}[] = [",
-            snake_case(tag),
-            camel_case(tag)
-        ))?;
+        let _ = writer.write("export const ".as_bytes())?;
+        write_snake_case(tag, &mut writer)?;
+        let _ = writer.write(": Tagged".as_bytes())?;
+        write_camel_case(tag, &mut writer)?;
+        let _ = writer.write("[] = [".as_bytes())?;
         if let Some(first) = id_iter.next() {
             writer.write_fmt(format_args!(" q{}", first))?;
             for id in id_iter {
@@ -44,10 +45,9 @@ pub fn generate(config: Arc<Config>, gen: Arc<GeneratedData>) -> std::io::Result
 
     for (tag, ids) in gen.collections.iter() {
         let mut id_iter = ids.iter();
-        writer.write_fmt(format_args!(
-            "export type Tagged{} = Merge<",
-            camel_case(tag)
-        ))?;
+        let _ = writer.write("export type Tagged".as_bytes())?;
+        write_camel_case(tag, &mut writer)?;
+        let _ = writer.write(" = Merge<".as_bytes())?;
         if let Some(first) = id_iter.next() {
             writer.write_fmt(format_args!("typeof q{}", first))?;
             for id in id_iter {

--- a/src/jobs/write_taxonomies.rs
+++ b/src/jobs/write_taxonomies.rs
@@ -5,9 +5,10 @@ use std::{
 
 use crate::{
     types::{Config, GeneratedData},
-    utils::{camel_case, snake_case},
+    utils::{write_camel_case, write_snake_case},
 };
 
+#[inline]
 pub fn generate(config: Arc<Config>, gen: Arc<GeneratedData>) -> std::io::Result<()> {
     std::fs::create_dir_all(&config.output)?;
     let file = std::fs::File::create(&config.output.join("taxonomies.ts"))?;
@@ -26,11 +27,11 @@ pub fn generate(config: Arc<Config>, gen: Arc<GeneratedData>) -> std::io::Result
 
     for (tag, ids) in gen.taxonomies.iter() {
         let mut id_iter = ids.iter();
-        writer.write_fmt(format_args!(
-            "export const {}: {}Tax[] = [",
-            snake_case(tag),
-            camel_case(tag)
-        ))?;
+        let _ = writer.write("export const ".as_bytes())?;
+        write_snake_case(tag, &mut writer)?;
+        let _ = writer.write(": ".as_bytes())?;
+        write_camel_case(tag, &mut writer)?;
+        let _ = writer.write("Tax[] = [".as_bytes())?;
         if let Some(first) = id_iter.next() {
             writer.write_fmt(format_args!(" q{}", first))?;
             for id in id_iter {
@@ -44,7 +45,9 @@ pub fn generate(config: Arc<Config>, gen: Arc<GeneratedData>) -> std::io::Result
 
     for (tag, ids) in gen.taxonomies.iter() {
         let mut id_iter = ids.iter();
-        writer.write_fmt(format_args!("export type {}Tax = Merge<", camel_case(tag)))?;
+        let _ = writer.write("export type ".as_bytes())?;
+        write_camel_case(tag, &mut writer)?;
+        let _ = writer.write("Tax = Merge<".as_bytes())?;
         if let Some(first) = id_iter.next() {
             writer.write_fmt(format_args!("typeof q{}", first))?;
             for id in id_iter {

--- a/src/jobs/write_taxonomies.rs
+++ b/src/jobs/write_taxonomies.rs
@@ -10,6 +10,9 @@ use crate::{
 
 #[inline]
 pub fn generate(config: Arc<Config>, gen: Arc<GeneratedData>) -> std::io::Result<()> {
+    if gen.taxonomies.is_empty() {
+        return Ok(());
+    }
     std::fs::create_dir_all(&config.output)?;
     let file = std::fs::File::create(&config.output.join("taxonomies.ts"))?;
     let mut writer = BufWriter::new(file);
@@ -31,7 +34,7 @@ pub fn generate(config: Arc<Config>, gen: Arc<GeneratedData>) -> std::io::Result
         write_snake_case(tag, &mut writer)?;
         let _ = writer.write(": ".as_bytes())?;
         write_camel_case(tag, &mut writer)?;
-        let _ = writer.write("Tax[] = [".as_bytes())?;
+        let _ = writer.write("[] = [".as_bytes())?;
         if let Some(first) = id_iter.next() {
             writer.write_fmt(format_args!(" q{}", first))?;
             for id in id_iter {
@@ -47,7 +50,7 @@ pub fn generate(config: Arc<Config>, gen: Arc<GeneratedData>) -> std::io::Result
         let mut id_iter = ids.iter();
         let _ = writer.write("export type ".as_bytes())?;
         write_camel_case(tag, &mut writer)?;
-        let _ = writer.write("Tax = Merge<".as_bytes())?;
+        let _ = writer.write(" = Merge<".as_bytes())?;
         if let Some(first) = id_iter.next() {
             writer.write_fmt(format_args!("typeof q{}", first))?;
             for id in id_iter {

--- a/src/jobs/write_type_helpers.rs
+++ b/src/jobs/write_type_helpers.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::types::Config;
 
+#[inline]
 pub fn generate(config: Arc<Config>) -> std::io::Result<()> {
     std::fs::create_dir_all(&config.output)?;
     let _ = std::fs::copy("src/helpers.ts", config.output.join("generated-helpers.ts"))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,14 +29,18 @@ fn main() {
     if !generated.output_paths.is_empty() {
         pool.execute(Job::WriteHelpers(config))
     }
+
+    println!("{} content files", generated.output_paths.len());
 }
 
+#[inline]
 fn process_content_dir(pool: &mut ThreadPool, config: Arc<Config>) -> GeneratedData {
     let mut gen = GeneratedData::default();
     process_content_rec(&config.input, pool, &mut gen, config.clone());
     gen
 }
 
+#[inline]
 fn process_content_rec(
     curr: &Path,
     pool: &mut ThreadPool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,11 +21,14 @@ fn main() {
     let input = PathBuf::from("examples/blog/src/content");
     let output = PathBuf::from("examples/blog/src/content-generated");
     let routes = PathBuf::from("examples/blog/src/routes");
+    if let Err(e) = std::fs::remove_dir_all(&output) {
+        println!("{}", e);
+    }
     let config = Arc::new(Config::new(input, output, routes));
     let mut pool = ThreadPool::new(8);
 
-    pool.execute(Job::GenerateRouteParams(config.clone()));
     let generated = Arc::new(process_content_dir(&mut pool, config.clone()));
+    pool.execute(Job::GenerateRouteParams(config.clone()));
     pool.execute(Job::GenerateTaxonomies(config.clone(), generated.clone()));
     pool.execute(Job::GenerateCollections(config.clone(), generated.clone()));
     if !generated.output_paths.is_empty() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use std::{borrow::Cow, ops::Range};
+use std::{borrow::Cow, io::Write, ops::Range};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ContentRanges {
@@ -7,6 +7,7 @@ pub struct ContentRanges {
     pub body: Range<usize>,
 }
 
+#[inline]
 pub fn get_content_ranges(content: &[u8]) -> ContentRanges {
     if !content.starts_with(b"---") {
         return ContentRanges {
@@ -33,6 +34,7 @@ pub fn get_content_ranges(content: &[u8]) -> ContentRanges {
     }
 }
 
+#[inline]
 pub fn capitalize(string: &str) -> Cow<'_, str> {
     if let Some(first) = string.chars().next() {
         if first.is_ascii_uppercase() {
@@ -45,8 +47,9 @@ pub fn capitalize(string: &str) -> Cow<'_, str> {
     }
     string.into()
 }
-pub fn camel_case(string: &str) -> String {
-    let mut camel_cased = String::new();
+
+#[inline]
+pub fn write_camel_case<W: Write>(string: &str, w: &mut W) -> std::io::Result<()> {
     let mut uppercase = true;
     for char in string.chars() {
         if char.is_whitespace() || char.is_ascii_punctuation() {
@@ -58,21 +61,22 @@ pub fn camel_case(string: &str) -> String {
         } else {
             char
         };
-        camel_cased.push(push);
+        let _ = w.write(&[push as u8])?;
         uppercase = false;
     }
-    camel_cased
+    Ok(())
 }
-pub fn snake_case(string: &str) -> String {
-    let mut snake_cased = String::new();
+
+#[inline]
+pub fn write_snake_case<W: Write>(string: &str, w: &mut W) -> std::io::Result<()> {
     for char in string.chars() {
         if char.is_whitespace() || char.is_ascii_punctuation() {
-            snake_cased.push('_');
+            let _ = w.write(&[b'_'])?;
             continue;
         }
-        snake_cased.push(char.to_ascii_lowercase());
+        let _ = w.write(&[char.to_ascii_lowercase() as u8])?;
     }
-    snake_cased
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -1,0 +1,783 @@
+use std::{io::Write, iter::Peekable, ops::Range, str::Chars};
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum YamlKind {
+    // Collection of Key/Value pairs
+    Object,
+    // A Key in a Yaml Object
+    Key,
+    // Collection of Yaml
+    List,
+
+    // Primitives
+    String,
+    Bool,
+    Number,
+    Null,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct YamlNode {
+    pub parent: usize,
+    pub kind: YamlKind,
+    range: (usize, usize),
+}
+
+#[allow(dead_code)]
+impl YamlNode {
+    pub fn range(&self) -> Range<usize> {
+        self.range.0..self.range.1
+    }
+    pub fn slice<'a>(&self, src: &'a str) -> &'a str {
+        &src[self.range()]
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Yaml<'a> {
+    src: &'a str,
+    inner: Vec<YamlNode>,
+}
+
+#[allow(dead_code)]
+impl<'a> Yaml<'a> {
+    pub fn inner(&self) -> &[YamlNode] {
+        &self.inner
+    }
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+    pub fn write_json<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
+        write_json_values_rec(&self.inner, self.src, w)?;
+        Ok(())
+    }
+    pub fn is_draft(&self) -> bool {
+        if let Some(draft_idx) = self
+            .inner
+            .iter()
+            .position(|n| n.kind == YamlKind::Key && n.slice(self.src) == "draft")
+        {
+            if let Some(node) = self.inner.get(draft_idx + 1) {
+                if node.kind == YamlKind::Bool {
+                    match node.slice(self.src) {
+                        "true" => return true,
+                        "false" => return false,
+                        _ => todo!("None true/false bool value"),
+                    }
+                }
+            }
+        }
+        false
+    }
+    pub fn get_tags(&'a self) -> Tags<'a> {
+        if let Some(tags_idx) = self
+            .inner
+            .iter()
+            .position(|n| n.kind == YamlKind::Key && n.slice(self.src) == "tags")
+        {
+            let list_idx = tags_idx + 1;
+            if let Some(node) = self.inner.get(list_idx) {
+                if node.kind == YamlKind::List {
+                    return Tags::from_slice(
+                        tags_idx + 2,
+                        self.src,
+                        self.inner.get(tags_idx + 2..).unwrap_or(&[]),
+                    );
+                    // if let Some(children) =  {
+                    //     for child in children.iter() {
+                    //         if child.parent != tags_idx + 2 {
+                    //             break;
+                    //         }
+                    //         if child.kind == YamlKind::String {
+                    //             tags.push(child.slice(self.src).to_owned())
+                    //         }
+                    //     }
+                    // }
+                }
+            }
+        }
+        Tags::from_slice(0, "", &[])
+    }
+}
+
+pub struct Parser<'a> {
+    src: &'a str,
+    chars: Peekable<Chars<'a>>,
+    start: usize,
+    curr: usize,
+    nodes: Vec<YamlNode>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum YamlError {
+    ExpectedKey,
+    ExpectedValue,
+    ExpectedQuote,
+    ExpectedDigit,
+}
+
+impl<'a> Parser<'a> {
+    pub fn from_str(src: &'a str) -> Self {
+        let trimmed = src.trim();
+        Self {
+            start: 0,
+            curr: 0,
+            chars: trimmed.chars().peekable(),
+            src: trimmed,
+            nodes: Vec::default(),
+        }
+    }
+    pub fn slice(&self) -> &str {
+        &self.src[self.start..self.curr]
+    }
+    pub fn peek(&mut self) -> Option<char> {
+        self.chars.peek().copied()
+    }
+    pub fn chomp(&mut self) {
+        if let Some(next) = self.chars.next() {
+            self.curr += next.len_utf8()
+        }
+    }
+    pub fn commit(&mut self) {
+        self.start = self.curr
+    }
+    pub fn skip_ws(&mut self) -> usize {
+        let mut count = 0;
+        loop {
+            match self.peek() {
+                Some(' ') => {
+                    count += 1;
+                    self.chomp()
+                }
+                Some('\t') => {
+                    count += 2;
+                    self.chomp()
+                }
+                _ => break,
+            }
+        }
+        count
+    }
+    pub fn push_node(&mut self, kind: YamlKind, parent: usize) -> usize {
+        self.nodes.push(YamlNode {
+            parent,
+            kind,
+            range: (self.start, self.curr),
+        });
+        self.nodes.len()
+    }
+    pub fn parse(mut self) -> Result<Yaml<'a>, YamlError> {
+        self.parse_object(0)?;
+        Ok(Yaml {
+            src: self.src,
+            inner: self.nodes,
+        })
+    }
+    pub fn parse_object(&mut self, parent: usize) -> Result<(), YamlError> {
+        // always expect a key
+        self.commit();
+        while self.peek().is_some() {
+            let key = self.parse_key(parent)?;
+            self.parse_value(key)?;
+            self.skip_ws();
+            while let Some('\r') | Some('\n') = self.peek() {
+                self.chomp();
+            }
+        }
+        Ok(())
+    }
+    fn parse_inline_list(&mut self, parent: usize) -> Result<(), YamlError> {
+        assert_eq!(self.peek(), Some('['));
+        self.chomp();
+        self.skip_ws();
+        self.commit();
+        let parent = self.push_node(YamlKind::List, parent);
+        loop {
+            self.skip_ws();
+            self.parse_value(parent)?;
+            self.skip_ws();
+            match self.peek() {
+                None => break,
+                Some(']') => {
+                    self.chomp();
+                    break;
+                }
+                Some(',') => {
+                    self.chomp();
+                    self.skip_ws();
+                    self.commit();
+                }
+                Some(c) => todo!("Unhandled {:?} in inline list", c),
+            }
+        }
+        self.commit();
+        Ok(())
+    }
+    fn parse_inline_object(&mut self, parent: usize) -> Result<(), YamlError> {
+        assert_eq!(self.peek(), Some('{'));
+        self.chomp();
+        self.skip_ws();
+        self.commit();
+        let parent = self.push_node(YamlKind::Object, parent);
+        loop {
+            match self.peek() {
+                Some('\r') | Some('\n') | Some('}') | None => break,
+                _ => {
+                    self.commit();
+                    let parent = self.parse_key(parent)?;
+                    self.skip_ws();
+                    self.parse_value(parent)?;
+                    self.skip_ws();
+                    if let Some(',') = self.peek() {
+                        self.chomp();
+                        self.skip_ws();
+                    }
+                }
+            }
+        }
+        assert_eq!(Some('}'), self.peek());
+        self.chomp();
+        self.commit();
+        Ok(())
+    }
+    fn parse_multiline_value(&mut self, parent: usize, indent: usize) -> Result<(), YamlError> {
+        match self.peek() {
+            Some('-') => self.parse_multiline_list_items(parent, indent),
+            _ => self.parse_multiline_object(parent, indent),
+        }
+    }
+    fn parse_multiline_list_items(
+        &mut self,
+        parent: usize,
+        indent: usize,
+    ) -> Result<(), YamlError> {
+        self.commit();
+        let parent = self.push_node(YamlKind::List, parent);
+        loop {
+            if !matches!(self.peek(), Some('-')) {
+                break;
+            }
+            self.chomp();
+            self.skip_ws();
+            self.commit();
+            self.parse_value(parent)?;
+            self.skip_ws();
+            match self.peek() {
+                Some('\r') | Some('\n') => {
+                    while let Some('\r') | Some('\n') = self.peek() {
+                        self.chomp();
+                    }
+                    let new_indent = self.skip_ws();
+                    if new_indent > indent {
+                        self.parse_multiline_value(parent, new_indent)?;
+                    }
+                    if new_indent < indent {
+                        break;
+                    }
+                }
+                _ => break,
+            }
+            self.commit()
+        }
+        Ok(())
+    }
+    fn parse_key(&mut self, parent: usize) -> Result<usize, YamlError> {
+        self.commit();
+        while let Some(next) = self.peek() {
+            if next == ':' {
+                let key = self.slice();
+                if key.is_empty() {
+                    return Err(YamlError::ExpectedKey);
+                }
+                let parent_idx = self.push_node(YamlKind::Key, parent);
+                self.chomp(); // Skip colon
+                self.skip_ws();
+                self.commit();
+                return Ok(parent_idx);
+            }
+            self.chomp()
+        }
+        Err(YamlError::ExpectedKey)
+    }
+    fn parse_multiline_object(&mut self, parent: usize, indent: usize) -> Result<(), YamlError> {
+        self.commit();
+        let parent = self.push_node(YamlKind::Object, parent);
+        loop {
+            let parent = self.parse_key(parent)?;
+            self.skip_ws();
+            self.commit();
+            self.parse_value(parent)?;
+            self.skip_ws();
+            match self.peek() {
+                Some('\r') | Some('\n') => {
+                    while let Some('\r') | Some('\n') = self.peek() {
+                        self.chomp();
+                    }
+                    let new_indent = self.skip_ws();
+                    if new_indent > indent {
+                        self.parse_multiline_value(parent, new_indent)?;
+                    }
+                    if new_indent < indent {
+                        break;
+                    }
+                }
+                _ => break,
+            }
+        }
+        Ok(())
+    }
+    fn parse_value(&mut self, parent: usize) -> Result<(), YamlError> {
+        match self.peek() {
+            None => Err(YamlError::ExpectedValue),
+            Some('[') => self.parse_inline_list(parent),
+            Some('{') => self.parse_inline_object(parent),
+            Some('\r') | Some('\n') => {
+                while let Some('\r') | Some('\n') = self.peek() {
+                    self.chomp();
+                }
+                let indent = self.skip_ws();
+                self.parse_multiline_value(parent, indent)
+            }
+            Some('"') | Some('\'') => self.parse_quoted_string(parent),
+            Some(char) => {
+                if char.is_ascii_digit() || char == '-' {
+                    self.parse_number(parent)
+                } else {
+                    self.parse_string_bool_null(parent)
+                }
+            }
+        }
+    }
+    fn parse_number(&mut self, parent: usize) -> Result<(), YamlError> {
+        let mut next = self.peek();
+        if next == Some('-') {
+            self.chomp();
+            next = self.peek();
+        }
+        if next.map(|c| !c.is_ascii_digit()).unwrap_or(false) {
+            return Err(YamlError::ExpectedDigit);
+        }
+        let mut is_decimal = false;
+        loop {
+            match self.peek() {
+                Some('\r') | Some('\n') | Some(',') | Some(']') | Some('}') | None => {
+                    self.push_node(YamlKind::Number, parent);
+                    self.commit();
+                    break;
+                }
+                Some(char) => {
+                    if char == '.' {
+                        if is_decimal {
+                            return self.parse_string_bool_null(parent);
+                        } else {
+                            is_decimal = true;
+                            self.chomp();
+                            continue;
+                        }
+                    }
+                    if !char.is_ascii_digit() {
+                        return self.parse_string_bool_null(parent);
+                    }
+                    self.chomp();
+                }
+            }
+        }
+        Ok(())
+    }
+    fn parse_quoted_string(&mut self, parent: usize) -> Result<(), YamlError> {
+        let quote = match self.peek() {
+            Some('\'') => '\'',
+            Some('"') => '"',
+            _ => return Err(YamlError::ExpectedQuote),
+        };
+        self.chomp();
+        loop {
+            match self.peek() {
+                Some(char) => {
+                    if char == quote {
+                        self.chomp();
+                        self.push_node(YamlKind::String, parent);
+                        self.commit();
+                        break;
+                    }
+                    self.chomp()
+                }
+                None => return Err(YamlError::ExpectedQuote),
+            }
+        }
+        Ok(())
+    }
+    fn parse_string_bool_null(&mut self, parent: usize) -> Result<(), YamlError> {
+        self.commit();
+        loop {
+            match self.peek() {
+                Some(',') | Some('\r') | Some('\n') | Some(']') | Some('}') | None => {
+                    let kind = match self.slice().trim_end() {
+                        "" => return Err(YamlError::ExpectedValue),
+                        "false" | "NO" | "true" | "YES" => YamlKind::Bool,
+                        "NULL" => YamlKind::Null,
+                        _ => YamlKind::String,
+                    };
+                    let mut real_curr = self.curr;
+                    for c in self.slice().chars().rev() {
+                        if !c.is_ascii_whitespace() {
+                            break;
+                        }
+                        real_curr -= 1;
+                    }
+                    self.nodes.push(YamlNode {
+                        parent,
+                        kind,
+                        range: (self.start, real_curr),
+                    });
+                    self.commit();
+                    break;
+                }
+                _ => self.chomp(),
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct Tags<'a> {
+    parent: usize,
+    src: &'a str,
+    state: u8,
+    inner: std::slice::Iter<'a, YamlNode>,
+}
+
+impl<'a> Tags<'a> {
+    pub fn from_slice(parent: usize, src: &'a str, nodes: &'a [YamlNode]) -> Self {
+        Self {
+            parent,
+            src,
+            state: 0,
+            inner: nodes.iter(),
+        }
+    }
+}
+
+impl<'a> Iterator for Tags<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.state == 1 {
+            return None;
+        }
+        loop {
+            let next = self.inner.next()?;
+            if next.parent < self.parent {
+                self.state = 1;
+                return None;
+            }
+            if next.kind == YamlKind::String {
+                return Some(next.slice(self.src));
+            }
+        }
+    }
+}
+
+#[inline]
+pub fn write_json_values_rec<W: Write>(
+    nodes: &[YamlNode],
+    src: &str,
+    w: &mut W,
+) -> std::io::Result<usize> {
+    let mut processed = 0;
+    let mut nodes_iter = nodes.iter().enumerate();
+    while let Some((idx, node)) = nodes_iter.next() {
+        let id = idx + 1;
+        match node.kind {
+            YamlKind::Object => {
+                w.write_all("{ ".as_bytes())?;
+                if id < nodes.len() {
+                    let end = nodes[idx + 1..]
+                        .iter()
+                        .position(|n| n.parent < id)
+                        .map(|i| i + id)
+                        .unwrap_or(nodes.len());
+                    for _ in 0..write_json_values_rec(&nodes[id..end], src, w)? {
+                        nodes_iter.next();
+                        processed += 1;
+                    }
+                }
+                w.write_all(" }".as_bytes())?;
+            }
+            YamlKind::Key => {
+                let slice = node
+                    .slice(src)
+                    .trim_start_matches(|c| c == '"' || c == '\'')
+                    .trim_end_matches(|c| c == '"' || c == '\'');
+                w.write_fmt(format_args!("\"{}\": ", slice))?;
+                if id < nodes.len() {
+                    let end = nodes[idx + 1..]
+                        .iter()
+                        .position(|n| n.parent < id)
+                        .map(|i| i + idx + 1)
+                        .unwrap_or(nodes.len());
+                    for _ in 0..write_json_values_rec(&nodes[id..end], src, w)? {
+                        nodes_iter.next();
+                        processed += 1;
+                    }
+                }
+            }
+            YamlKind::List => {
+                w.write_all("[ ".as_bytes())?;
+                if id < nodes.len() {
+                    let end = nodes[id..]
+                        .iter()
+                        .position(|n| n.parent < id)
+                        .map(|i| i + id)
+                        .unwrap_or(nodes.len());
+                    for _ in 0..write_json_values_rec(&nodes[id..end], src, w)? {
+                        nodes_iter.next();
+                        processed += 1;
+                    }
+                }
+                w.write_all(" ]".as_bytes())?;
+            }
+            YamlKind::String => {
+                let slice = node
+                    .slice(src)
+                    .trim_start_matches(|c| c == '"' || c == '\'')
+                    .trim_end_matches(|c| c == '"' || c == '\'');
+                w.write_fmt(format_args!("\"{}\"", slice))?;
+            }
+            YamlKind::Bool => w.write_all(node.slice(src).as_bytes())?,
+            YamlKind::Number => w.write_all(node.slice(src).as_bytes())?,
+            YamlKind::Null => w.write_all("undefined".as_bytes())?,
+        }
+        processed += 1;
+        if processed < nodes.len() {
+            w.write_all(", ".as_bytes())?;
+        }
+    }
+    Ok(processed)
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::{write_json_values_rec, Parser, Yaml, YamlKind};
+
+    fn expect_nodes(src: &str, yaml: Yaml, expected: Vec<(&str, YamlKind, usize)>) {
+        assert_eq!(yaml.len(), expected.len());
+        for (index, node) in yaml.inner().iter().enumerate() {
+            let (slice, kind, parent) = expected.get(index).unwrap();
+            assert_eq!(*slice, node.slice(src));
+            assert_eq!(*kind, node.kind);
+            assert_eq!(*parent, node.parent);
+        }
+    }
+
+    #[test]
+    fn it_parses_bool_true() {
+        let src = "draft: true";
+        let yaml = Parser::from_str(src).parse().unwrap();
+        let expected = vec![("draft", YamlKind::Key, 0), ("true", YamlKind::Bool, 1)];
+        expect_nodes(src, yaml, expected);
+    }
+    #[test]
+    fn it_parses_bool_false() {
+        let src = "draft: false";
+        let yaml = Parser::from_str(src).parse().unwrap();
+        let expected = vec![("draft", YamlKind::Key, 0), ("false", YamlKind::Bool, 1)];
+        expect_nodes(src, yaml, expected);
+    }
+    #[test]
+    fn it_parses_bool_null() {
+        let src = "draft: NULL";
+        let yaml = Parser::from_str(src).parse().unwrap();
+        let expected = vec![("draft", YamlKind::Key, 0), ("NULL", YamlKind::Null, 1)];
+        expect_nodes(src, yaml, expected);
+    }
+    #[test]
+    fn it_parses_unquoted_string() {
+        let src = "key: An unquoted string";
+        let yaml = Parser::from_str(src).parse().unwrap();
+        let expected = vec![
+            ("key", YamlKind::Key, 0),
+            ("An unquoted string", YamlKind::String, 1),
+        ];
+        expect_nodes(src, yaml, expected);
+    }
+    #[test]
+    fn it_parses_quoted_string() {
+        let src = "key: A quoted string";
+        let yaml = Parser::from_str(src).parse().unwrap();
+        let expected = vec![
+            ("key", YamlKind::Key, 0),
+            ("A quoted string", YamlKind::String, 1),
+        ];
+        expect_nodes(src, yaml, expected);
+    }
+    #[test]
+    fn it_parses_a_number() {
+        let src = "key: 42";
+        let yaml = Parser::from_str(src).parse().unwrap();
+        let expected = vec![("key", YamlKind::Key, 0), ("42", YamlKind::Number, 1)];
+        expect_nodes(src, yaml, expected);
+    }
+    #[test]
+    fn it_parses_a_negative_number() {
+        let src = "key: -42";
+        let yaml = Parser::from_str(src).parse().unwrap();
+        let expected = vec![("key", YamlKind::Key, 0), ("-42", YamlKind::Number, 1)];
+        expect_nodes(src, yaml, expected);
+    }
+    #[test]
+    fn it_parses_a_decimal_number() {
+        let src = "key: 42.0";
+        let yaml = Parser::from_str(src).parse().unwrap();
+        let expected = vec![("key", YamlKind::Key, 0), ("42.0", YamlKind::Number, 1)];
+        expect_nodes(src, yaml, expected);
+    }
+    #[test]
+    fn it_parses_a_negative_decimal_number() {
+        let src = "key: -42.0";
+        let yaml = Parser::from_str(src).parse().unwrap();
+        let expected = vec![("key", YamlKind::Key, 0), ("-42.0", YamlKind::Number, 1)];
+        expect_nodes(src, yaml, expected);
+    }
+    #[test]
+    fn it_parses_multiple_key_values() {
+        let src = ["first: -42.0", "second: false", "third: Hello world!"].join("\n");
+        let yaml = Parser::from_str(&src).parse().unwrap();
+        let expected = vec![
+            ("first", YamlKind::Key, 0),
+            ("-42.0", YamlKind::Number, 1),
+            ("second", YamlKind::Key, 0),
+            ("false", YamlKind::Bool, 3),
+            ("third", YamlKind::Key, 0),
+            ("Hello world!", YamlKind::String, 5),
+        ];
+        expect_nodes(&src, yaml, expected);
+    }
+    #[test]
+    fn it_parses_inline_list() {
+        let src = "key: [\"A\", false, 42, Hello World]";
+        let yaml = Parser::from_str(src).parse().unwrap();
+        let expected = vec![
+            ("key", YamlKind::Key, 0),
+            ("", YamlKind::List, 1),
+            ("\"A\"", YamlKind::String, 2),
+            ("false", YamlKind::Bool, 2),
+            ("42", YamlKind::Number, 2),
+            ("Hello World", YamlKind::String, 2),
+        ];
+        expect_nodes(src, yaml, expected)
+    }
+    #[test]
+    fn it_parses_inline_object() {
+        let src = "key: { a: \"A\", b: false, c: 42, d: Hello World }";
+        let yaml = Parser::from_str(src).parse().unwrap();
+        let expected = vec![
+            ("key", YamlKind::Key, 0),
+            ("", YamlKind::Object, 1),
+            ("a", YamlKind::Key, 2),
+            ("\"A\"", YamlKind::String, 3),
+            ("b", YamlKind::Key, 2),
+            ("false", YamlKind::Bool, 5),
+            ("c", YamlKind::Key, 2),
+            ("42", YamlKind::Number, 7),
+            ("d", YamlKind::Key, 2),
+            ("Hello World", YamlKind::String, 9),
+        ];
+        expect_nodes(src, yaml, expected)
+    }
+    #[test]
+    fn it_parses_multiline_lists() {
+        let src = vec!["key:", " - A", " - \"B\"", " - false", " - 42"].join("\n");
+        let expected = vec![
+            ("key", YamlKind::Key, 0),
+            ("", YamlKind::List, 1),
+            ("A", YamlKind::String, 2),
+            ("\"B\"", YamlKind::String, 2),
+            ("false", YamlKind::Bool, 2),
+            ("42", YamlKind::Number, 2),
+        ];
+        let yaml = Parser::from_str(&src).parse().unwrap();
+        expect_nodes(&src, yaml, expected);
+    }
+    #[test]
+    fn it_parses_nested_multiline_lists() {
+        let src = vec!["key:", " - A", " - \"B\"", "   - false", "   - 42"].join("\n");
+        let expected = vec![
+            ("key", YamlKind::Key, 0),
+            ("", YamlKind::List, 1),
+            ("A", YamlKind::String, 2),
+            ("\"B\"", YamlKind::String, 2),
+            ("", YamlKind::List, 2),
+            ("false", YamlKind::Bool, 5),
+            ("42", YamlKind::Number, 5),
+        ];
+        let yaml = Parser::from_str(&src).parse().unwrap();
+        expect_nodes(&src, yaml, expected);
+    }
+    #[test]
+    fn it_parses_multiline_objects() {
+        let src = vec!["key:", "  a: \"A\"", "  b: B", "  c: false", "  d: 42"].join("\n");
+        let yaml = Parser::from_str(&src).parse().unwrap();
+        let expected = vec![
+            ("key", YamlKind::Key, 0),
+            ("", YamlKind::Object, 1),
+            ("a", YamlKind::Key, 2),
+            ("\"A\"", YamlKind::String, 3),
+            ("b", YamlKind::Key, 2),
+            ("B", YamlKind::String, 5),
+            ("c", YamlKind::Key, 2),
+            ("false", YamlKind::Bool, 7),
+            ("d", YamlKind::Key, 2),
+            ("42", YamlKind::Number, 9),
+        ];
+        expect_nodes(&src, yaml, expected);
+    }
+    #[test]
+    fn parses_full_yaml() {
+        let src = vec![
+            "title: Some title",
+            "description: \"A description\"",
+            "draft: true",
+            "navigation:",
+            "  key: A Key",
+            "  weight: 0",
+            "tags: [\"fun\", \"qwik\", \"stuff\"]",
+        ]
+        .join("\n");
+        let yaml = Parser::from_str(&src).parse().unwrap();
+        for (idx, node) in yaml.inner().iter().enumerate() {
+            println!(
+                "{{id: {}, parent: {}, kind: {:?} }}",
+                idx + 1,
+                node.parent,
+                node.kind,
+            )
+        }
+        let mut out = Vec::default();
+        write_json_values_rec(yaml.inner(), &src, &mut out).unwrap();
+        println!("{}", String::from_utf8(out).unwrap())
+    }
+    #[test]
+    fn it_can_be_draft() {
+        let src = "draft: true";
+        let yaml = Parser::from_str(src).parse().unwrap();
+        assert!(yaml.is_draft())
+    }
+    #[test]
+    fn it_can_have_tags() {
+        let src = "tags: [\"fun\", \"qwik\", \"stuff\"]";
+        let yaml = Parser::from_str(src).parse().unwrap();
+        for tag in yaml.get_tags() {
+            println!("{:?}", tag);
+        }
+    }
+    #[test]
+    fn it_writes_multiple_key_values() {
+        let src = ["first: -42.0", "second: false", "third: Hello world!"].join("\n");
+        let yaml = Parser::from_str(&src).parse().unwrap();
+        let mut out: Vec<u8> = Vec::default();
+        write_json_values_rec(yaml.inner(), &src, &mut out).unwrap();
+        println!("{}", String::from_utf8(out).unwrap());
+    }
+}


### PR DESCRIPTION
Features:
- Implements a new handwritten yaml parser that is up 10x faster than serde_yaml
- Parses yaml into a flat vec instead of a BTreeMap
- Write pages directly instead of creating an intermediate page object
- Allow draft content

Fixes #7, #10, #11 